### PR TITLE
Adds "nigg" to profanity list

### DIFF
--- a/ProfanityFilter/ProfanityFilter/ProfanityList.cs
+++ b/ProfanityFilter/ProfanityFilter/ProfanityList.cs
@@ -1081,6 +1081,7 @@ namespace ProfanityFilter
              "negro",
              "neonazi",
              "nig nog",
+             "nigg",
              "nigaboo",
              "nigg3r",
              "nigg4h",


### PR DESCRIPTION
During usage of this library, we noticed a player of our `game-off-2022` submitted the name "nigg".